### PR TITLE
fix: remove null optional elements before jsonencode is called

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -5,4 +5,5 @@ An end-to-end example that provisions the following infrastructure:
 - A resource group, if one is not passed in.
 - A Key Protect instance with a root key.
 - An instance of Databases for etcd with BYOK encryption and autoscaling.
+- Set 250 max connection for Databases for etcd instance.
 - Service credentials for the database instance.

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -42,4 +42,7 @@ module "etcd_db" {
   tags                       = var.resource_tags
   access_tags                = var.access_tags
   service_credential_names   = var.service_credential_names
+  configuration = {
+    max_connections = 250
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -51,6 +51,7 @@ resource "ibm_database" "etcd_db" {
   tags              = var.tags
   adminpassword     = var.admin_pass
   service_endpoints = var.service_endpoints
+  # remove attributes with null values: see https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/273
   configuration     = var.configuration != null ? jsonencode({ for k, v in var.configuration : k => v if v != null }) : null
 
   key_protect_key           = var.kms_key_crn

--- a/main.tf
+++ b/main.tf
@@ -51,8 +51,8 @@ resource "ibm_database" "etcd_db" {
   tags              = var.tags
   adminpassword     = var.admin_pass
   service_endpoints = var.service_endpoints
-  # remove attributes with null values: see https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/273
-  configuration     = var.configuration != null ? jsonencode({ for k, v in var.configuration : k => v if v != null }) : null
+  # remove elements with null values: see https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/273
+  configuration = var.configuration != null ? jsonencode({ for k, v in var.configuration : k => v if v != null }) : null
 
   key_protect_key           = var.kms_key_crn
   backup_encryption_key_crn = local.backup_encryption_key_crn

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,7 @@ resource "ibm_database" "etcd_db" {
   tags              = var.tags
   adminpassword     = var.admin_pass
   service_endpoints = var.service_endpoints
-  configuration     = var.configuration != null ? jsonencode(var.configuration) : null
+  configuration     = var.configuration != null ? jsonencode({ for k, v in var.configuration : k => v if v != null }) : null
 
   key_protect_key           = var.kms_key_crn
   backup_encryption_key_crn = local.backup_encryption_key_crn

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -456,7 +456,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 174
+        "line": 175
       }
     },
     "ibm_resource_tag.etcd_tag": {
@@ -472,7 +472,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 123
+        "line": 124
       }
     }
   },
@@ -492,7 +492,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 202
+        "line": 203
       }
     }
   },
@@ -571,7 +571,7 @@
       },
       "pos": {
         "filename": "main.tf",
-        "line": 134
+        "line": 135
       }
     }
   }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -100,6 +100,8 @@ func TestRunCompleteUpgradeExample(t *testing.T) {
 	})
 
 	output, err := options.RunTestUpgrade()
-	assert.Nil(t, err, "This should not have errored")
-	assert.NotNil(t, output, "Expected some output")
+	if !options.UpgradeTestSkipped {
+		assert.Nil(t, err, "This should not have errored")
+		assert.NotNil(t, output, "Expected some output")
+	}
 }


### PR DESCRIPTION
### Description

jsonencode sets null for any optional value that is not set. postgresql API doesn't like that. We need to remove null versions. 

https://github.com/terraform-ibm-modules/terraform-ibm-icd-postgresql/issues/273

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
